### PR TITLE
Fix/four bugs

### DIFF
--- a/src/txtai_mcp_server/core/config.py
+++ b/src/txtai_mcp_server/core/config.py
@@ -1,6 +1,7 @@
 """Configuration for txtai MCP server."""
 import os
 import logging
+import tarfile, json
 from pathlib import Path
 from typing import Dict, Any, Optional, Literal, Union, Tuple
 
@@ -47,7 +48,6 @@ class TxtAISettings(BaseSettings):
     
     def _detect_model_from_archive(self, kb_path: str) -> str:
         """Read embedding model path from KB config.json to prevent dimension mismatch."""
-        import tarfile, json
         try:
             with tarfile.open(kb_path) as tar:
                 # txtai stores embeddings config as config.json or embeddings/config.json

--- a/src/txtai_mcp_server/core/config.py
+++ b/src/txtai_mcp_server/core/config.py
@@ -45,6 +45,27 @@ class TxtAISettings(BaseSettings):
         """Load settings from environment and .env file."""
         return cls.model_validate({})  # Empty dict will load from env vars
     
+    def _detect_model_from_archive(self, kb_path: str) -> str:
+        """Read embedding model path from KB config.json to prevent dimension mismatch."""
+        import tarfile, json
+        try:
+            with tarfile.open(kb_path) as tar:
+                # txtai stores embeddings config as config.json or embeddings/config.json
+                for candidate in ["config.json", "./config.json", "embeddings/config.json"]:
+                    try:
+                        f = tar.extractfile(candidate)
+                        if f:
+                            cfg = json.load(f)
+                            model = cfg.get("path")
+                            if model:
+                                logger.info(f"Detected embedding model from KB archive: {model}")
+                                return model
+                    except KeyError:
+                        continue
+        except Exception as e:
+            logger.warning(f"Could not detect model from KB archive: {e}")
+        return self.model_path  # safe fallback — keep current value
+
     def create_application(self) -> Application:
         """Create txtai Application instance.
         
@@ -71,8 +92,12 @@ class TxtAISettings(BaseSettings):
             logger.info(f"Creating Application from embeddings path: {self.embeddings_path}")
             # For embeddings path, we need to use a YAML string with the path
             if os.path.isfile(self.embeddings_path) and self.embeddings_path.endswith(('.tar.gz', '.tgz')):
-                # For archive files, use a YAML string with the path
+                # For archive files, detect model from KB config.json to prevent dimension mismatch
                 logger.info(f"Loading embeddings from archive file: {self.embeddings_path}")
+                detected_model = self._detect_model_from_archive(self.embeddings_path)
+                if detected_model != self.model_path:
+                    logger.info(f"Overriding model_path {self.model_path} with KB-detected model: {detected_model}")
+                    self.model_path = detected_model
                 return Application(f"path: {self.embeddings_path}")
             else:
                 # For directories, load directly

--- a/src/txtai_mcp_server/tools/qa.py
+++ b/src/txtai_mcp_server/tools/qa.py
@@ -85,7 +85,7 @@ def register_qa_tools(mcp: FastMCP) -> None:
                 sql_query = f"select text, answer, score from txtai where similar('{safe_question}') limit 1"
                 results = app.search(sql_query)
                 
-                if results and len(results) > 0 and "answer" in results[0]:
+                if results and len(results) > 0 and results[0].get("answer"):
                     return results[0]["answer"]
             except Exception as e:
                 logger.info(f"Error getting answer field: {str(e)}, falling back to text field")

--- a/src/txtai_mcp_server/tools/qa.py
+++ b/src/txtai_mcp_server/tools/qa.py
@@ -85,7 +85,7 @@ def register_qa_tools(mcp: FastMCP) -> None:
                 sql_query = f"select text, answer, score from txtai where similar('{safe_question}') limit 1"
                 results = app.search(sql_query)
                 
-                if results and len(results) > 0 and results[0].get("answer"):
+                if results and results[0].get("answer"):
                     return results[0]["answer"]
             except Exception as e:
                 logger.info(f"Error getting answer field: {str(e)}, falling back to text field")

--- a/src/txtai_mcp_server/tools/search.py
+++ b/src/txtai_mcp_server/tools/search.py
@@ -90,7 +90,7 @@ def register_search_tools(mcp: FastMCP) -> None:
                         "text": node_data.get("text", "No text available"),
                         "score": node_data.get("score", 0.0),
                         "centrality": results.centrality()[node_id],
-                        "connections": len(results.neighbors(node_id))
+                        "connections": len(results.edges(node_id) or {})
                     }
                     
                     formatted_results.append(formatted_node)

--- a/src/txtai_mcp_server/tools/search.py
+++ b/src/txtai_mcp_server/tools/search.py
@@ -115,8 +115,8 @@ def register_search_tools(mcp: FastMCP) -> None:
                         text = get_document_from_cache(doc_id)
                         if not text:
                             try:
-                                app = get_txtai_app()
-                                sql_result = app.search(f"select text from txtai where id = '{escape_sql_string(doc_id)}'")
+                                safe_id = escape_sql_string(str(doc_id))
+                                sql_result = app.search(f"select text from txtai where id = '{safe_id}'")
                                 text = sql_result[0].get("text", "No text available") if sql_result else "No text available"
                             except Exception:
                                 text = "No text available"

--- a/src/txtai_mcp_server/tools/search.py
+++ b/src/txtai_mcp_server/tools/search.py
@@ -116,7 +116,7 @@ def register_search_tools(mcp: FastMCP) -> None:
                         if not text:
                             try:
                                 app = get_txtai_app()
-                                sql_result = app.search(f"select text from txtai where id = '{doc_id}'")
+                                sql_result = app.search(f"select text from txtai where id = '{escape_sql_string(doc_id)}'")
                                 text = sql_result[0].get("text", "No text available") if sql_result else "No text available"
                             except Exception:
                                 text = "No text available"

--- a/src/txtai_mcp_server/tools/search.py
+++ b/src/txtai_mcp_server/tools/search.py
@@ -112,7 +112,14 @@ def register_search_tools(mcp: FastMCP) -> None:
                         score = result["score"]
                         
                         # Try to get the document text from the cache
-                        text = get_document_from_cache(doc_id) or "No text available"
+                        text = get_document_from_cache(doc_id)
+                        if not text:
+                            try:
+                                app = get_txtai_app()
+                                sql_result = app.search(f"select text from txtai where id = '{doc_id}'")
+                                text = sql_result[0].get("text", "No text available") if sql_result else "No text available"
+                            except Exception:
+                                text = "No text available"
                         logger.info(f"Retrieved document {doc_id}: text available: {text != 'No text available'}")
                         
                         # Add formatted result


### PR DESCRIPTION
## Fix four bugs affecting KB-loaded MCP server instances

### Bug 1 — `fix(config)`: Auto-detect embedding model from KB archive
Hardcoded `all-MiniLM-L6-v2` caused silent dimension mismatch when KB
was built with a different model. Adds `_detect_model_from_archive()`
to read model path from `config.json` inside the tar at load time.

### Bug 2 — `fix(qa)`: Check answer field value not just key presence
`results[0]["answer"]` exists as a key but with value `None` in plain
text KBs. `.get("answer")` truthiness check prevents `None` propagating
as return value → fixes Pydantic `Input should be a valid string` error.

### Bug 3 — `fix(search)`: Replace undefined `neighbors()` with `edges()`
The txtai NetworkX wrapper does not expose `neighbors()`. Calling it
raises `AttributeError` on any `semantic_search` with `graph=True`.

### Bug 4 — `fix(search)`: SQL fallback when document cache empty on startup
`document_cache` is only populated via `add_documents()` at runtime.
Fresh startup from tar archive always has empty cache → all results
return `"No text available"` despite content existing in SQLite.
SQL fallback resolves text directly from the DB on cache miss.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically detect and load the correct embedding model from archived knowledge bases at startup.

* **Bug Fixes**
  * QA tool now reliably checks for actual answer content.
  * Document retrieval falls back from cache to database when text is missing.
  * Graph search shows more accurate connection counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->